### PR TITLE
Add  `gcc_multi` to make `native_sim` build work

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,7 @@
 , python38
 , newScope
 , openocd
+, gcc_multi
 , autoreconfHook
 , fetchFromGitHub
 }:
@@ -202,4 +203,7 @@ in {
       '';
     })
     { };
+
+    # other needed dependencies
+    gcc_multi
 })


### PR DESCRIPTION
I've had problem running `west build -b native_sim zephyr/samples/hello_world` receiving the error
```bash
/nix/store/b0s2lkf593r3585038ws4jd3lylf2wdx-glibc-2.38-44-dev/include/gnu/stubs.h:7:11: fatal error: gnu/stubs-32.h: No such file or directory
    7 | # include <gnu/stubs-32.h>
```
By adding `gcc_multi` to the packages in my shell the compilation completes successfully so I think that this package is missing. I'm a newbie to both zephyr and nix so probably there are some problems in the pr but please let me know what you think.

Thanks.